### PR TITLE
Added stateless = true as default for steam openID

### DIFF
--- a/lib/passport-steam/strategy.js
+++ b/lib/passport-steam/strategy.js
@@ -42,7 +42,7 @@ function Strategy(options, validate) {
   options = options || {};
   options.providerURL = options.providerURL || 'http://steamcommunity.com/openid';
   options.profile =  (options.profile === undefined) ? true : options.profile;
-
+  options.stateless = true; //Steam only works as a stateless OpenID
   OpenIDStrategy.call(this, options, validate);
   this.name = 'steam';
 }


### PR DESCRIPTION
Steam only seems to run as a stateless OpenID server.  I added stateless = true to the default options so no one else runs into the debugging issues I did.
