### PR TITLE
Updating passport-openid to avoid an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/passport-steam",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-openid": "~0.1.2"
+    "passport-openid": "~0.2.3"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
``` javascript
./node_modules/passport-steam/node_modules/passport-openid/node_modules/openid/openid.js:333
    provider.endpoint = service.uri;
                               ^
TypeError: Cannot read property 'uri' of undefined
```
