### PR TITLE
Get profile information using the Steam Web API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,18 @@ Additionally, options can be supplied to specify a return URL and realm.
 
     passport.use(new SteamStrategy({
         returnURL: 'http://localhost:3000/auth/steam/return',
-        realm: 'http://localhost:3000/'
+        realm: 'http://localhost:3000/',
+        apiKey: 'your steam API key'
       },
-      function(identifier, done) {
+      function(identifier, profile, done) {
         User.findByOpenID({ openId: identifier }, function (err, user) {
           return done(err, user);
         });
       }
     ));
+
+A Steam API key can be obtained at http://steamcommunity.com/dev/apikey. You
+can use the strategy without a key if you pass ``profile: false`` instead.
 
 #### Authenticate Requests
 

--- a/lib/passport-steam/strategy.js
+++ b/lib/passport-steam/strategy.js
@@ -2,7 +2,8 @@
  * Module dependencies.
  */
 var util = require('util')
-  , OpenIDStrategy = require('passport-openid').Strategy;
+  , OpenIDStrategy = require('passport-openid').Strategy
+  , SteamWebAPI = require('steam-web');
 
 
 /**
@@ -43,7 +44,32 @@ function Strategy(options, validate) {
   options.providerURL = options.providerURL || 'http://steamcommunity.com/openid';
   options.profile =  (options.profile === undefined) ? true : options.profile;
   options.stateless = true; //Steam only works as a stateless OpenID
-  OpenIDStrategy.call(this, options, validate);
+
+  if(options.profile) {
+    var steam = new SteamWebAPI({ apiKey: options.apiKey, format: 'json' });
+
+    function getUserProfile(identifier, profile, done) {
+      steam.getPlayerSummaries({
+        steamids: [ identifier ],
+        callback: function(err, result) {
+          profile = {
+            provider: 'steam',
+            _json: result.response.players[0],
+            id: result.response.players[0].steamid,
+            displayName: result.response.players[0].personaname,
+            photos: [ { value: result.response.players[0].avatar }, { value: result.response.players[0].avatarmedium }, { value: result.response.players[0].avatarfull } ]
+          };
+
+          validate(identifier, profile, done);
+        }
+      });
+    }
+
+    OpenIDStrategy.call(this, options, getUserProfile);
+  } else {
+    OpenIDStrategy.call(this, options, validate);
+  }
+
   this.name = 'steam';
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "main": "./lib/passport-steam",
   "dependencies": {
     "pkginfo": "*",
-    "passport-openid": "*"
+    "passport-openid": "*",
+    "steam-web": "~0.2.1"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
Steam doesn't support the standard OpenID profile downloaded by passport-openid so the profile returned was empty.

This pull request implements getting the profile using the Steam Web API instead, which actually returns useful data. It requires that users get a (free, immediately available) API key from Steam though. As with other passport strategies, people can specify `profile: false` to disable requesting profiles entirely, in which case a Steam API key is not required.

You'll want to bump the major version number before releasing an update since this is a breaking API change.
