### PR TITLE
Updated dependencies to own fork to allow support for node 6.0.0

### DIFF
--- a/lib/passport-steam/strategy.js
+++ b/lib/passport-steam/strategy.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 var util = require('util')
-  , OpenIDStrategy = require('passport-openid').Strategy
+  , OpenIDStrategy = require('passport-openid-node6support').Strategy
   , SteamWebAPI = require('steam-web');
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-steam",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Steam (OpenID) authentication strategy for Passport.",
   "author": {
     "name": "Liam Curry",
@@ -32,7 +32,7 @@
   "main": "./lib/passport-steam",
   "dependencies": {
     "pkginfo": "*",
-    "passport-openid": "^0.4.0",
+    "passport-openid-node6support": "^1.0.0",
     "steam-web": "~0.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Tests pass, the old example works, and #33's Koa example works. Tested on Node 6.0.0.