### PR TITLE
Patches issue #35

### DIFF
--- a/lib/passport-steam/strategy.js
+++ b/lib/passport-steam/strategy.js
@@ -47,7 +47,7 @@ function Strategy(options, validate) {
 
   if(options.profile) {
     var steam = new SteamWebAPI({ apiKey: options.apiKey, format: 'json' });
-    var identCheck = /^http:\/\/steamcommunity.com\/openid\/id\/(\d+$)/.exec(arguments[options.passReqToCallback ? () : 0]);
+    var identCheck = /^http:\/\/steamcommunity.com\/openid\/id\/(\d+$)/.exec(arguments[options.passReqToCallback ? 1 : 0]);
     
     function getUserProfile() {
       var req = arguments[options.passReqToCallback ? 0 : undefined];

--- a/lib/passport-steam/strategy.js
+++ b/lib/passport-steam/strategy.js
@@ -47,10 +47,11 @@ function Strategy(options, validate) {
 
   if(options.profile) {
     var steam = new SteamWebAPI({ apiKey: options.apiKey, format: 'json' });
-
+    var identCheck = /^http:\/\/steamcommunity.com\/openid\/id\/(\d+$)/.exec(arguments[options.passReqToCallback ? () : 0]);
+    
     function getUserProfile() {
       var req = arguments[options.passReqToCallback ? 0 : undefined];
-      var identifier = arguments[options.passReqToCallback ? 1 : 0];
+      var identifier = identCheck === null ? 0 : identCheck[1];
       var profile = arguments[options.passReqToCallback ? 2 : 1];
       var done = arguments[options.passReqToCallback ? 3 : 2];
 


### PR DESCRIPTION
Patches #35

Updated strategy.js to first validate the URL of the returned identifier, and then extract the SteamID. If the URL isn't validated correctly, a SteamID of 0 is returned. 