### PR TITLE
update steam-web dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "pkginfo": "*",
     "passport-openid-node6support": "^1.0.0",
-    "steam-web": "~0.2.4"
+    "steam-web": "0.3.0"
   },
   "devDependencies": {
     "ava": "^0.10.0",


### PR DESCRIPTION
See this issue for context:
https://github.com/odota/core/issues/1206

0.2.4 will return errors for users with "404 Not Found" in their personanames.

Commit with fix:
https://github.com/Tidwell/nodeSteam/commit/8df27b7aa627afc137699105d9b0c08892472a77#diff-3b927a3e0a0ff68cc4acfd1b8382b693L249