### PR TITLE
Use passport-openid

### DIFF
--- a/lib/passport-steam/strategy.js
+++ b/lib/passport-steam/strategy.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 var util = require('util')
-  , OpenIDStrategy = require('passport-openid-node6support').Strategy
+  , OpenIDStrategy = require('passport-openid').Strategy
   , SteamWebAPI = require('steam-web');
 
 /**

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "main": "./lib/passport-steam",
   "dependencies": {
     "pkginfo": "*",
-    "passport-openid": "^0.x",
+    "passport-openid": "^0.4.0",
     "steam-web": "0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "main": "./lib/passport-steam",
   "dependencies": {
     "pkginfo": "*",
-    "passport-openid-node6support": "^1.0.0",
+    "passport-openid": "^0.x",
     "steam-web": "0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi !

Passport-openid-node6support seem to be no longer maintain and cause somes issues.
It's maybe more appropriate to use the "official" passport-openid create by @jaredhanson.

This fix the issue #49 related by @feedarz

This is tested on node v6.9.1 by my self 
and on node v4.7.0 by @feedarz