### PR TITLE
Changed http -> https in provider URL due to recent Steam changes

### DIFF
--- a/lib/passport-steam/strategy.js
+++ b/lib/passport-steam/strategy.js
@@ -76,7 +76,7 @@ function getUserProfile(key, steamID, callback) {
  */
 function Strategy(options, validate) {
   options = options || {};
-  options.providerURL = options.providerURL || 'http://steamcommunity.com/openid';
+  options.providerURL = options.providerURL || 'https://steamcommunity.com/openid';
   options.profile =  (options.profile === undefined) ? true : options.profile;
   options.stateless = true; //Steam only works as a stateless OpenID
 
@@ -85,7 +85,7 @@ function Strategy(options, validate) {
 
   function verify(req, identifier, profile, done) {
     var validOpEndpoint = 'https://steamcommunity.com/openid/login';
-    var identifierRegex = /^http:\/\/steamcommunity\.com\/openid\/id\/(\d+)$/;
+    var identifierRegex = /^https:\/\/steamcommunity\.com\/openid\/id\/(\d+)$/;
 
     if(req.query['openid.op_endpoint'] !== validOpEndpoint ||
        !identifierRegex.test(identifier)) {

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -11,7 +11,7 @@ function getStrategy () {
 }
 
 test("Whether the providerURL is steam's", t => {
-  t.same(getStrategy()._providerURL, 'http://steamcommunity.com/openid')
+  t.same(getStrategy()._providerURL, 'https://steamcommunity.com/openid')
 });
 
 test("Whether the strategy name is 'steam'", t => {


### PR DESCRIPTION
For now steamcommunity.com redirects http -> https. This library is now broken. 
This pull request should fix that problem by changing provider URL's to https.