### PR TITLE
Use https as the openid providerURL

### DIFF
--- a/lib/passport-steam/strategy.js
+++ b/lib/passport-steam/strategy.js
@@ -76,7 +76,7 @@ function getUserProfile(key, steamID, callback) {
  */
 function Strategy(options, validate) {
   options = options || {};
-  options.providerURL = options.providerURL || 'http://steamcommunity.com/openid';
+  options.providerURL = options.providerURL || 'https://steamcommunity.com/openid';
   options.profile =  (options.profile === undefined) ? true : options.profile;
   options.stateless = true; //Steam only works as a stateless OpenID
 

--- a/lib/passport-steam/strategy.js
+++ b/lib/passport-steam/strategy.js
@@ -85,7 +85,7 @@ function Strategy(options, validate) {
 
   function verify(req, identifier, profile, done) {
     var validOpEndpoint = 'https://steamcommunity.com/openid/login';
-    var identifierRegex = /^http:\/\/steamcommunity\.com\/openid\/id\/(\d+)$/;
+    var identifierRegex = /^https?:\/\/steamcommunity\.com\/openid\/id\/(\d+)$/;
 
     if(req.query['openid.op_endpoint'] !== validOpEndpoint ||
        !identifierRegex.test(identifier)) {


### PR DESCRIPTION
Really not sure why this wasn't always using HTTPS.

In any event, SteamCommunity now forces https and this library breaks without the following changes.

Cheers