### PR TITLE
Avoid reading property of undefined when Steam is down

### DIFF
--- a/lib/passport-steam/strategy.js
+++ b/lib/passport-steam/strategy.js
@@ -23,6 +23,10 @@ function getUserProfile(key, steamID, callback) {
         return callback(err);
       }
 
+      if(!(result && result.response && Array.isArray(result.response.players) && result.response.players.length > 0)) {
+        return callback(new Error('Malformed response while retrieving user\'s Steam profile information'));
+      }
+
       var profile = {
         provider: 'steam',
         _json: result.response.players[0],


### PR DESCRIPTION
Today Steam was down and while retrieving user's steam profile information we got this:
```
{ response: { players: [] } }
```

To get to this result I did:
```
...
steam.getPlayerSummaries({
    steamids: [ steamID ],
    callback: function(err, result) {
      if(err) {
        return callback(err);
      }

      console.log(result);
...
```
And I was getting the error
```
/home/daniel/Documentos/Nesha/nesha-core/node_modules/passport-steam/lib/passport-steam/strategy.js:29
        id: result.response.players[0].steamid,
                                       ^

TypeError: Cannot read property 'steamid' of undefined
    at callback (/home/daniel/Documentos/Nesha/nesha-core/node_modules/passport-steam/lib/passport-steam/strategy.js:29:40)
    at IncomingMessage.<anonymous> (/home/daniel/Documentos/Nesha/nesha-core/node_modules/steam-web/lib/steam.js:484:7)
    at IncomingMessage.emit (node:events:381:22)
    at endReadableNT (node:internal/streams/readable:1307:12)
    at processTicksAndRejections (node:internal/process/task_queues:81:21)
```
To get around this we can just check if everything we will be accessing are defined.
Note that this is very important to handle because we use NestJs and it has a built-in ExceptionHandler so we do not have to worry about those stuff, but some how this is not caught by this exception handler. The side effect is that the application exits and this is really bad. I might open an issue in the Nest project to see if we can avoid this as well because this might happen with another libraries as well. But for now, fixing it in this one will stop killing applications. Also note that this scenario only exists when Steam is down or with issues (which is not so hard to happen).
